### PR TITLE
Feature: Be compatible with MySQL 8.0

### DIFF
--- a/src/PointType.php
+++ b/src/PointType.php
@@ -72,7 +72,7 @@ class PointType extends Type
      */
     public function convertToPHPValueSQL($value, $platform): string
     {
-        return sprintf('AsText(%s)', $value);
+        return sprintf('ST_AsText(%s)', $value);
     }
 
     /**
@@ -82,6 +82,6 @@ class PointType extends Type
      */
     public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
-        return sprintf('PointFromText(%s)', $sqlExpr);
+        return sprintf('ST_PointFromText(%s)', $sqlExpr);
     }
 }


### PR DESCRIPTION
Since, MySQL 8.0; there are some deprecated functions.
See https://mysqlserverteam.com/detecting-incompatible-use-of-spatial-functions-before-upgrading-to-mysql-8-0/ for all deprecated functions. However there are some aliases that do work! 
Works with MySQL 5.7 as well.